### PR TITLE
updated docs and parallelism-throttling script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
-# centaur
-Cromwell integration testing environment. Do an 'sbt test'
+# Introduction
+Centaur is an integration testing suite for the [Cromwell](http://github.com/broadinstitute/cromwell) execution server.  It's purpose is to exercise the functionality of a specific deployment of Cromwell, to ensure that it is functioning properly 'in the wild'.  
+
+# Prerequisites
+
+Centaur expects to find a Cromwell server properly configured and running in server mode, listening on port 8000.  This can be configured by modifying the `cromwellUrl` parameter in `application.conf`.
+
+# Running
+
+There are two ways run invoke the intergration tests:
+* `sbt test` - compiles and run via sbt directly, simple but also has the problem of running 2*cores tests in parallel which can overwhelm your Cromwell server if running in a development environment
+* `run_tests_parallel.sh [THREADS]` - runs the same tests with an enforced parallelism limit.  Defaults to `3` if not specified
+
+# FAQs
+
+##### I'm seeing a bunch of timeout errors in my tests
+This is because you are trying to drive your poor Cromwell too hard!  Typically this happens when you are running everything on your local machine and are using a high level of parallelism (e.g. running via `sbt test`).  Reduce your parallelism by using `run_tests_parallel.sh` instead and/or beef up your configuration
 
 ![Image of a Centaur](https://upload.wikimedia.org/wikipedia/commons/3/34/Centaur_IV_tank_of_'H'_Troop,_2nd_Battery,_Royal_Marine_Armoured_Support_Group,_13_June_1944._B5457.jpg)
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,15 @@ val sprayV = "1.3.3"
 val downgradedSprayV = "1.3.2"
 val akkaV = "2.3.14"
 
+
+/***
+ * by default log buffering is set to true in sbt, which means
+ * that for tests executed in parallel you will not see the 
+ * output until the test suite completes.  Setting this to false
+ * will not buffer output, but it will be interleaved
+ */
+// logBuffered in Test := false
+
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.3.0",
   "org.typelevel" %% "cats" % "0.4.1",

--- a/run_tests_parallel.sh
+++ b/run_tests_parallel.sh
@@ -1,0 +1,15 @@
+#
+# This approach allows for the running of scalatests that mixin the
+# trait 'ParallelTestExecution' to be executed in parallel with a
+# throttle to the number of threads.  Simply running 'sbt test' 
+# has that throttle hardcoded to be 2*cores
+#
+
+# optional parameter for parallelism, defaults to 3
+THREADS=${1:-3}
+
+echo "Running tests with ${THREADS}-way parallelism"
+
+sbt test:compile
+CP=$(sbt "export test:dependency-classpath" --error)
+java -cp $CP org.scalatest.tools.Runner -R target/scala-2.11/test-classes -oD -PS${THREADS}


### PR DESCRIPTION
Just a few brief updates to

(a) improve the documentation
(b) add information about how to throttle parallelism for tests
