### PR TITLE
New-world lacking submit failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ The `basePath` field is optional, but if supplied all paths will be resolved fro
 
 The `testFormat` field can be one of the following, case insensitive:
 * `workflowsuccess`: The workflow being supplied is expected to successfully complete
-* `workflowfailure`: The workflow being supplied is expected to fail 
-* `submissionfailure`: The workflow being supplied is expected to fail on workflow submission
+* `workflowfailure`: The workflow being supplied is expected to fail
 
 The `metadata` is optional. If supplied, Centaur will retrieve the metadata from the successfully completed workflow and compare the values retrieved to those supplied. At the moment the only fields supported are strings, numbers and booleans.
 

--- a/src/main/resources/standardTestCases/bad_workflow_failure_mode.test
+++ b/src/main/resources/standardTestCases/bad_workflow_failure_mode.test
@@ -1,5 +1,5 @@
 name: bad_workflow_failure_mode
-testFormat: submissionfailure
+testFormat: workflowfailure
 
 files {
   wdl: bad_workflow_failure_mode/bad_workflow_failure_mode.wdl

--- a/src/main/scala/centaur/test/formulas/TestFormulas.scala
+++ b/src/main/scala/centaur/test/formulas/TestFormulas.scala
@@ -22,7 +22,6 @@ object TestFormulas {
 
   def runSuccessfulWorkflow(workflow: Workflow): Test[SubmittedWorkflow] = runWorkflowUntilTerminalStatus(workflow, Succeeded)
   def runFailingWorkflow(workflow: Workflow): Test[SubmittedWorkflow] = runWorkflowUntilTerminalStatus(workflow, Failed)
-  def runSubmissionFailureWorkflow(workflow: Workflow): Test[String] = submitWorkflowExpectingRejection(workflow)
 
   def runSuccessfulWorkflowAndVerifyMetadata(workflow: Workflow): Test[Unit] = {
     // FIXME: This is horrible, but I want to get the issue closed, will come back and make this more type safe

--- a/src/main/scala/centaur/test/standard/StandardTestCase.scala
+++ b/src/main/scala/centaur/test/standard/StandardTestCase.scala
@@ -7,7 +7,7 @@ import cats.Apply
 import cats.std.list._
 import centaur.test._
 import centaur.test.formulas.TestFormulas
-import centaur.test.standard.StandardTestFormat.{SubmissionFailureTest, WorkflowFailureTest, WorkflowSuccessTest}
+import centaur.test.standard.StandardTestFormat.{WorkflowFailureTest, WorkflowSuccessTest}
 import centaur.test.workflow.Workflow
 import centaur.test.workflow.Workflow.{WorkflowWithMetadata, WorkflowWithoutMetadata}
 import com.typesafe.config.{Config, ConfigFactory}
@@ -18,7 +18,6 @@ case class StandardTestCase(workflow: Workflow, testFormat: StandardTestFormat) 
   def testFunction = this.testFormat match {
     case WorkflowSuccessTest => successfulTestFunction
     case WorkflowFailureTest => TestFormulas.runFailingWorkflow _
-    case SubmissionFailureTest => TestFormulas.runSubmissionFailureWorkflow _
   }
 
   private def successfulTestFunction = this.workflow match {

--- a/src/test/scala/centaur/StandardTestCaseSpec.scala
+++ b/src/test/scala/centaur/StandardTestCaseSpec.scala
@@ -12,7 +12,7 @@ import centaur.test.workflow.Workflow
 import scala.language.postfixOps
 import org.scalatest._
 
-class StandardTestCaseSpec extends FlatSpec with Matchers with ParallelTestExecution{
+class StandardTestCaseSpec extends FlatSpec with Matchers with ParallelTestExecution {
   def testCases(basePath: Path): List[StandardTestCase] = {
     // IntelliJ will give some red squiggles in the following block. It lies.
     basePath.toFile.listFiles.toList collect { case x if x.isFile => x.toPath } traverse StandardTestCase.fromPath match {


### PR DESCRIPTION
Fixed a problem with a test expecting submission failures in the old w…orld, whereas in the new world they would be accepted.
