### PR TITLE
Added some tag options to allow for customised test runs. Closes #46

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ There are two ways to invoke the intergration tests:
 * `sbt test` - compiles and run via sbt directly, simple but also has the problem of running 2*cores tests in parallel which can overwhelm your Cromwell server if running in a development environment
 * `run_tests_parallel.sh [THREADS]` - runs the same tests with an enforced parallelism limit.  Defaults to `3` if not specified
 
+## Tags
+
+All tests are tagged with their name and their TESTFORMAT, and also any custom tags specified in the `.test` file.
+To run only those tests which have been tagged with a specified tag `tagFoo`:
+```
+sbt "test-only * -- -n tagFoo"
+```
+
+Or to instead exclude all tests which have been tagged with a specified tag `tagFoo`:
+```
+sbt "test-only * -- -l tagFoo"
+```
+
 # Adding custom tests
 
 You can add your own tests to the test suite by adding `-Dcentaur.optionalTestPath=DIR` on your sbt invocation, 
@@ -20,6 +33,7 @@ which contains one or more test case files. Each test case file is a HOCON file 
 name: NAME
 testFormat: TESTFORMAT
 basePath: /an/optional/field
+tags: [ "any", "custom", "tags" ]
 
 files {
   wdl: path/to/wdl
@@ -32,6 +46,8 @@ metadata {
   fully.qualified.key.name2: VALUE2
 }
 ```
+
+The tags are optional. If supplied they will allow people to turn on or off this test case by including or excluding tags when running (see above).
 
 The `basePath` field is optional, but if supplied all paths will be resolved from that directory. If it is not supplied, all paths will be resolved from the directory the test case file is in.
 

--- a/src/main/resources/standardTestCases/lots_of_inputs.test
+++ b/src/main/resources/standardTestCases/lots_of_inputs.test
@@ -1,5 +1,6 @@
 name: lots_of_inputs
 testFormat: workflowsuccess
+tags: [ big_metadata ]
 
 files {
   wdl: lots_of_inputs/lots_of_inputs.wdl

--- a/src/main/scala/centaur/test/TagsStrings.scala
+++ b/src/main/scala/centaur/test/TagsStrings.scala
@@ -1,0 +1,16 @@
+package centaur.test
+
+import cats.data.Validated._
+import com.typesafe.config.Config
+import configs.Result.{Failure, Success}
+import configs.syntax._
+
+object TagsStrings {
+
+  def fromConfig(conf: Config): ErrorOr[List[String]] = {
+    conf.get[List[String]]("tags") match {
+      case Success(tagStrings) => Valid(tagStrings.map(_.toLowerCase).distinct)
+      case Failure(_) => Valid(List.empty[String])
+    }
+  }
+}

--- a/src/main/scala/centaur/test/standard/StandardTestCase.scala
+++ b/src/main/scala/centaur/test/standard/StandardTestCase.scala
@@ -14,7 +14,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 
 import scala.util.{Failure, Success, Try}
 
-case class StandardTestCase(workflow: Workflow, testFormat: StandardTestFormat) {
+case class StandardTestCase(workflow: Workflow, testFormat: StandardTestFormat, tagStrings: List[String]) {
   def testFunction = this.testFormat match {
     case WorkflowSuccessTest => successfulTestFunction
     case WorkflowFailureTest => TestFormulas.runFailingWorkflow _
@@ -37,6 +37,7 @@ object StandardTestCase {
   def fromConfig(conf: Config, configPath: Path): ErrorOr[StandardTestCase] = {
     val workflow = Workflow.fromConfig(conf, configPath)
     val format = StandardTestFormat.fromConfig(conf)
-    Apply[ErrorOr].map2(workflow, format)((w, f) => StandardTestCase(w, f))
+    val tags = TagsStrings.fromConfig(conf)
+    Apply[ErrorOr].map3(workflow, format, tags)((w, f, t) => StandardTestCase(w, f, t))
   }
 }

--- a/src/test/scala/centaur/StandardTestCaseSpec.scala
+++ b/src/test/scala/centaur/StandardTestCaseSpec.scala
@@ -28,8 +28,17 @@ class StandardTestCaseSpec extends FlatSpec with Matchers with ParallelTestExecu
   }
 
   def executeStandardTest(testCase: StandardTestCase, f: Workflow => Test[_]): Unit = {
-    it should s"${testCase.testFormat.testSpecString} ${testCase.workflow.name}" in {
-      f(testCase.workflow).run.get
+
+    def nameTest = it should s"${testCase.testFormat.testSpecString} ${testCase.workflow.name}"
+    def runTest = f(testCase.workflow).run.get
+
+    // Make tags, but enforce lowercase:
+    val tags = (testCase.tagStrings :+ testCase.workflow.name :+ testCase.testFormat.name) map { x => Tag(x) }
+
+    tags match {
+      case Nil => nameTest in runTest
+      case head :: Nil => nameTest taggedAs head in runTest
+      case head :: tail => nameTest taggedAs(head, tail: _*) in runTest
     }
   }
 }


### PR DESCRIPTION
In this scheme, every test is Standard test is tagged with its TestFormat type, test name, and any custom tags provided in the `.test` file.

Example usage is:

```
sbt "test-only * -- -n tagFoo"
```

This example runs only the tests which have been tagged with `tagFoo`
