### PR TITLE
Fixes for monitoring test.  Closes broadinstitute/cromwell#1006

### DIFF
--- a/src/main/resources/standardTestCases/monitoring.test
+++ b/src/main/resources/standardTestCases/monitoring.test
@@ -1,16 +1,13 @@
-#Currently doesn't work in 0.20, monitoring log is empty
-
 name: monitoring
 testFormat: workflowsuccess
-tags: ignore
 
 files {
   wdl: monitoring/monitoring.wdl
-  #options: monitoring/monitoring.options
+  options: monitoring/monitoring.options
 }
 
 metadata {
   workflowName: monitoring
   status: Succeeded
-  #"calls.monitoring.simpleNeasy.monitoring_script": "gs://cloud-cromwell-dev/cromwell_execution/monitoring/<<UUID>>/call-simpleNeasy/monitoring.log"
+  "calls.monitoring.simpleNeasy.jes.monitoringLog": "<<WORKFLOW_ROOT>>/call-simpleNeasy/monitoring.log"
 }

--- a/src/main/resources/standardTestCases/monitoring/monitoring.wdl
+++ b/src/main/resources/standardTestCases/monitoring/monitoring.wdl
@@ -1,6 +1,7 @@
 task simpleNeasy {
     command {
        echo "This test is easy, breezy"
+       sleep 10
     }
     output {
         String out = read_string(stdout())

--- a/src/main/scala/centaur/test/metadata/WorkflowMetadata.scala
+++ b/src/main/scala/centaur/test/metadata/WorkflowMetadata.scala
@@ -14,14 +14,15 @@ import scala.util.{Failure, Success, Try}
 
 case class WorkflowMetadata(value: Map[String, JsValue]) extends AnyVal {
 
-  def diff(other: WorkflowMetadata, workflowID: UUID): Iterable[String] = {
-    val missingErrors = value.keySet.diff(other.value.keySet) map { k => s"Missing key: $k" }
-    val mismatchErrors = value.keySet.intersect(other.value.keySet) flatMap { k => diffValues(k, value(k), other.value(k), workflowID) }
+  def diff(actual: WorkflowMetadata, workflowID: UUID): Iterable[String] = {
+    lazy val workflowRoot = actual.value.get("workflowRoot").get.asInstanceOf[JsString].value
+    val missingErrors = value.keySet.diff(actual.value.keySet) map { k => s"Missing key: $k" }
+    val mismatchErrors = value.keySet.intersect(actual.value.keySet) flatMap { k => diffValues(k, value(k), actual.value(k), workflowID, workflowRoot) }
 
     mismatchErrors ++ missingErrors
   }
 
-  private def diffValues(key: String, expected: JsValue, other: JsValue, workflowID: UUID): Option[String] = {
+  private def diffValues(key: String, expected: JsValue, actual: JsValue, workflowID: UUID, workflowRoot: String): Option[String] = {
     /*
       FIXME/TODO:
 
@@ -31,17 +32,18 @@ case class WorkflowMetadata(value: Map[String, JsValue]) extends AnyVal {
       entirely likely that it won't survive long term.
      */
 
-    lazy val sanitisedExpectedUUID = expected.toString.replace("<<UUID>>", workflowID.toString)
 
-    val isMatch = other match {
-      case o: JsString => sanitisedExpectedUUID == o.toString
+    lazy val substitutedValue = expected.toString.replace("<<UUID>>", workflowID.toString).replace("<<WORKFLOW_ROOT>>", workflowRoot)
+
+    val isMatch = actual match {
+      case o: JsString => substitutedValue == o.toString
       case o: JsNumber => expected == JsString(o.value.toString)
       case o: JsBoolean => expected == JsString(o.value.toString)
       case _ => false
     }
 
     if (isMatch) None
-    else Option(s"Metadata mismatch for $key - expected: $sanitisedExpectedUUID but got: $other")
+    else Option(s"Metadata mismatch for $key - expected: $substitutedValue but got: $actual")
   }
 
 }


### PR DESCRIPTION
Handle WORKFLOW_ROOT as a metavalue in an expectation, turn on the monitoring test, cleanup.
