### PR TITLE
Retry metadata validation for N seconds to account for eventual consi…

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -5,6 +5,8 @@ centaur {
   sendReceiveTimeout: 10 seconds
   # The maximal length of a workflow, intended as a sanity check and not actually a test in and of itself
   maxWorkflowLength: 2 hours
+  # Cromwell's metadata is eventually consistent. Set a timeout such that we expect it to have eventually consisted
+  metadataConsistencyTimeout: 10 seconds
 
   # Path (absolute or relative) where Centaur will look for test cases. The expectation is that each test
   # case will be in a subdirectory named FOO with files FOO.wdl, FOO.inputs, and FOO.options. This is not

--- a/src/main/scala/centaur/CentaurConfig.scala
+++ b/src/main/scala/centaur/CentaurConfig.scala
@@ -12,6 +12,7 @@ object CentaurConfig {
   lazy val cromwellUrl = new URL(conf.getString("centaur.cromwellUrl"))
   lazy val sendReceiveTimeout = conf.getDuration("centaur.sendReceiveTimeout").toScala
   lazy val maxWorkflowLength = conf.getDuration("centaur.maxWorkflowLength").toScala
+  lazy val metadataConsistencyTimeout = conf.getDuration("centaur.metadataConsistencyTimeout").toScala
 
   lazy val standardTestCasePath = Paths.get(conf.getString("centaur.standardTestCasePath"))
   lazy val callCacheTestCasePath = Paths.get(conf.getString("centaur.callCacheTestCasePath"))

--- a/src/main/scala/centaur/test/Test.scala
+++ b/src/main/scala/centaur/test/Test.scala
@@ -99,23 +99,29 @@ object Operations {
     }
   }
 
-  def retrieveMetadata(workflow: SubmittedWorkflow): Test[WorkflowMetadata] = {
-    new Test[WorkflowMetadata] {
-      override def run: Try[WorkflowMetadata] = {
-        val response = MetadataRequest(Get(CentaurConfig.cromwellUrl + "/api/workflows/v2/" + workflow.id + "/metadata"))
-        // Try to convert the response to a Metadata in our return Try.
-        // Currently any error msg will be opaque as it's unlikely to be an issue (can flesh out later)
-        sendReceiveFutureCompletion(response map { r => WorkflowMetadata.fromMetadataJson(r).toOption.get })
-      }
-    }
-  }
 
-  def validateMetadata(retrievedMetadata: WorkflowMetadata, expectedMetadata: WorkflowMetadata, workflowID: UUID): Test[Unit] = {
+
+
+  def validateMetadata(workflow: SubmittedWorkflow, expectedMetadata: WorkflowMetadata): Test[Unit] = {
+    val consistencyTimeout = Future { Thread.sleep(CentaurConfig.metadataConsistencyTimeout.toMillis) }
+
     new Test[Unit] {
+      def validateMetadataUntilTimeout(workflow: SubmittedWorkflow, expectedMetadata: WorkflowMetadata): Try[Unit] = {
+          val response = MetadataRequest(Get(CentaurConfig.cromwellUrl + "/api/workflows/v2/" + workflow.id + "/metadata"))
+          // Try to convert the response to a Metadata in our return Try.
+          // Currently any error msg will be opaque as it's unlikely to be an issue (can flesh out later)
+          val metadata = sendReceiveFutureCompletion(response map { r => WorkflowMetadata.fromMetadataJson(r).toOption.get })
+          metadata.map(expectedMetadata.diff(_, workflow.id)) match {
+            case Success(d) if d.isEmpty => Success()
+            case Success(d) if consistencyTimeout.isCompleted =>
+              Failure(throw new Exception(s"Invalid metadata response:\n -${d.mkString("\n -")}\n"))
+            case Success(_) =>  validateMetadataUntilTimeout(workflow, expectedMetadata)
+            case Failure(e) => Failure(e)
+          }
+      }
+
       override def run: Try[Unit] = {
-        val diffs = expectedMetadata diff(retrievedMetadata, workflowID)
-        if (diffs.isEmpty) Success(())
-        else Failure(throw new Exception(s"Invalid metadata response:\n -${diffs.mkString("\n -")}\n"))
+        validateMetadataUntilTimeout(workflow, expectedMetadata)
       }
     }
   }
@@ -134,6 +140,17 @@ object Operations {
     }
   }
 
+  def retrieveMetadata(workflow: SubmittedWorkflow): Test[WorkflowMetadata] = {
+    new Test[WorkflowMetadata] {
+      override def run: Try[WorkflowMetadata] = {
+        val response = MetadataRequest(Get(CentaurConfig.cromwellUrl + "/api/workflows/v2/" + workflow.id + "/metadata"))
+        // Try to convert the response to a Metadata in our return Try.
+        // Currently any error msg will be opaque as it's unlikely to be an issue (can flesh out later)
+        sendReceiveFutureCompletion(response map { r => WorkflowMetadata.fromMetadataJson(r).toOption.get })
+      }
+    }
+  }
+
   /**
     * Ensure that the Future completes within the specified timeout. If it does not, or if the Future fails,
     * will return a Failure, otherwise a Success
@@ -141,6 +158,7 @@ object Operations {
   def awaitFutureCompletion[T](x: Future[T], timeout: FiniteDuration) = Try(Await.result(x, timeout))
   def sendReceiveFutureCompletion[T](x: Future[T]) = awaitFutureCompletion(x, CentaurConfig.sendReceiveTimeout)
   def workflowLengthFutureCompletion[T](x: Future[T]) = awaitFutureCompletion(x, CentaurConfig.maxWorkflowLength)
+  def metadataFutureCompletion[T](x: Future[T]) = awaitFutureCompletion(x, CentaurConfig.metadataConsistencyTimeout)
 
   // Spray needs an implicit ActorSystem
   implicit val system = ActorSystem("centaur-foo")

--- a/src/main/scala/centaur/test/Test.scala
+++ b/src/main/scala/centaur/test/Test.scala
@@ -99,9 +99,6 @@ object Operations {
     }
   }
 
-
-
-
   def validateMetadata(workflow: SubmittedWorkflow, expectedMetadata: WorkflowMetadata): Test[Unit] = {
     val consistencyTimeout = Future { Thread.sleep(CentaurConfig.metadataConsistencyTimeout.toMillis) }
 


### PR DESCRIPTION
…stency

Note: This very prominently punts the issue on the call caching tests which aren't being run anyways. I didn't feel like figuring out the right abstraction to kill both birds with but a single stone at this time.
