### PR TITLE
Update failure metadata path

### DIFF
--- a/src/main/resources/standardTestCases/invalid_runtime_attributes.test
+++ b/src/main/resources/standardTestCases/invalid_runtime_attributes.test
@@ -7,5 +7,5 @@ files {
 }
 
 metadata {
-    "failures.0": "Task invalid_runtime_attributes has an invalid runtime attribute continueOnReturnCode = \"oops\""
+    "failures.0.message": "Task invalid_runtime_attributes has an invalid runtime attribute continueOnReturnCode = \"oops\""
 }

--- a/src/main/resources/standardTestCases/invalid_wdl.test
+++ b/src/main/resources/standardTestCases/invalid_wdl.test
@@ -6,5 +6,5 @@ files {
 }
 
 metadata {
-  "failures.0": "Unable to load namespace from workflow: ERROR: Unexpected symbol (line 1, col 15) when parsing 'task'.\n\nExpected lbrace, got <string:1:15 rbrace \"fQ==\">.\n\ntask blahblah }{\n              ^\n\n$task = :task :identifier :lbrace $_gen3 $_gen4 :rbrace -> Task( name=$1, declarations=$3, sections=$4 )\n     "
+  "failures.0.message": "Unable to load namespace from workflow: ERROR: Unexpected symbol (line 1, col 15) when parsing 'task'.\n\nExpected lbrace, got <string:1:15 rbrace \"fQ==\">.\n\ntask blahblah }{\n              ^\n\n$task = :task :identifier :lbrace $_gen3 $_gen4 :rbrace -> Task( name=$1, declarations=$3, sections=$4 )\n     "
 }

--- a/src/main/resources/standardTestCases/invalid_wdl.test
+++ b/src/main/resources/standardTestCases/invalid_wdl.test
@@ -6,5 +6,5 @@ files {
 }
 
 metadata {
-  "failures.0.message": "Unable to load namespace from workflow: ERROR: Unexpected symbol (line 1, col 15) when parsing 'task'.\n\nExpected lbrace, got <string:1:15 rbrace \"fQ==\">.\n\ntask blahblah }{\n              ^\n\n$task = :task :identifier :lbrace $_gen3 $_gen4 :rbrace -> Task( name=$1, declarations=$3, sections=$4 )\n     "
+  "failures.0.message": "Workflow input processing failed.\nUnable to load namespace from workflow: ERROR: Unexpected symbol (line 1, col 15) when parsing 'task'.\n\nExpected lbrace, got <string:1:15 rbrace \"fQ==\">.\n\ntask blahblah }{\n              ^\n\n$task = :task :identifier :lbrace $_gen3 $_gen4 :rbrace -> Task( name=$1, declarations=$3, sections=$4 )\n     "
 }


### PR DESCRIPTION
This is related to the change in https://github.com/broadinstitute/cromwell/pull/1084
I don't know what the procedure is to merge this kind of changes though. Because if this is merged,  those centaur tests will fail on branches not rebased on top of the cromwell PR above (including develop until it's merged). And the PR above will not go green until this is merged...
I ran centaur manually with those changes on the cromwell branch and it passed though.
