### PR TITLE
preemptible VMs are subject to preemption.  

### DIFF
--- a/src/main/resources/standardTestCases/confirm_preemptible/confirm_preemptible.wdl
+++ b/src/main/resources/standardTestCases/confirm_preemptible/confirm_preemptible.wdl
@@ -18,7 +18,7 @@ task check_preemption {
 
 
 workflow confirm_preemptible {
-  call check_preemption as yes { input: set_preemptible = 1 }
+  call check_preemption as yes { input: set_preemptible = 5 }
   call check_preemption as no  { input: set_preemptible = 0 }
 
   output {


### PR DESCRIPTION
@geoffjentry spotted this test failing in the wild which turned out to be because I had set the preemptible value to 1.  The preemptible VM was preempted so Cromwell reran the job as non-preemptible.  The task succeeded, but the VM metadata correctly reported that the run was not preemptible and the test failed.

Try running the VM as preemptible more than once.  The choice of value won't be perfect, but it's certainly preferable to 1 or infinity.