### PR TITLE
Build updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Tag names are all lower case, so a test named "tagFoo" has a tag "tagfoo".
 
 To run only those tests which have been tagged with a specified tag `tagFoo`:
 ```
-sbt "test-only * -- -n tagfoo"
+sbt "testOnly * -- -n tagfoo"
 ```
 
 Or to instead exclude all tests which have been tagged with a specified tag `tagFoo`:
 ```
-sbt "test-only * -- -l tagfoo"
+sbt "testOnly * -- -l tagfoo"
 ```
 
 # Adding custom tests

--- a/build.sbt
+++ b/build.sbt
@@ -17,10 +17,16 @@ val akkaV = "2.4.11" // Note: akka-http branches from akkaV after 2.4.11
 libraryDependencies ++= Seq(
   "com.github.kxbmap" %% "configs" % "0.4.2",
   "com.typesafe" % "config" % "1.3.0",
-  "org.typelevel" %% "cats" % "0.7.2",
+  "org.typelevel" %% "cats" % "0.7.2"
+    exclude("org.typelevel", "cats-laws_2.11")
+    exclude("org.typelevel", "cats-kernel-laws_2.11"),
   "com.typesafe.akka" %% "akka-actor" % akkaV,
   "com.typesafe.akka" %% "akka-http-experimental" % akkaV,
   "com.typesafe.akka" %% "akka-http-spray-json-experimental" % akkaV,
-  "org.scalatest" %% "scalatest" % "2.2.6" % Test,
-  "com.github.pathikrit" %% "better-files" % "2.13.0"
+  "com.github.pathikrit" %% "better-files" % "2.13.0",
+  //---------- Test libraries -------------------//
+  "org.scalatest" %% "scalatest" % "3.0.1" % Test,
+  "org.pegdown" % "pegdown" % "1.6.0" % Test
 )
+
+testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDSI", "-h", "target/test-reports")


### PR DESCRIPTION
More info generated during scalatest.
Excluding scalacheck from the build.
Fixed README references to old hyphenated sbt key names.