### PR TITLE
Fail on underscores test.

### DIFF
--- a/src/main/resources/standardTestCases/gcs_fail_on_underscores.test
+++ b/src/main/resources/standardTestCases/gcs_fail_on_underscores.test
@@ -1,0 +1,14 @@
+name: gcs_fail_on_underscores
+testFormat: workflowfailure
+backends: [Jes]
+
+files {
+  inputs: gcs_fail_on_underscores/gcs_fail_on_underscores.inputs
+  wdl: gcs_fail_on_underscores/gcs_fail_on_underscores.wdl
+}
+
+metadata {
+  workflowName: size_wf
+  "calls.size_wf.size_task.failures.0.causedBy.0.causedBy.0.causedBy.0.message": "The bucket name in GCS path 'gs://centaur_bucket_name_with_underscores/gumby.png' is not compatible with URI host name standards. URI host name compatibility is a requirement for Cromwell's GCS filesystem support. Google also generally advises against the use of underscores in GCS bucket names, as well as against the use of periods or dashes in certain patterns as described here: https://cloud.google.com/storage/docs/naming. In particular, the bucket name in 'gs://centaur_bucket_name_with_underscores/gumby.png' may contain an underscore which is not a valid character in a URI host."
+  "failures.0.causedBy.0.causedBy.0.causedBy.0.message": "The bucket name in GCS path 'gs://centaur_bucket_name_with_underscores/gumby.png' is not compatible with URI host name standards. URI host name compatibility is a requirement for Cromwell's GCS filesystem support. Google also generally advises against the use of underscores in GCS bucket names, as well as against the use of periods or dashes in certain patterns as described here: https://cloud.google.com/storage/docs/naming. In particular, the bucket name in 'gs://centaur_bucket_name_with_underscores/gumby.png' may contain an underscore which is not a valid character in a URI host."
+}

--- a/src/main/resources/standardTestCases/gcs_fail_on_underscores/gcs_fail_on_underscores.inputs
+++ b/src/main/resources/standardTestCases/gcs_fail_on_underscores/gcs_fail_on_underscores.inputs
@@ -1,0 +1,3 @@
+{
+  "size_wf.file": "gs://centaur_bucket_name_with_underscores/gumby.png"
+}

--- a/src/main/resources/standardTestCases/gcs_fail_on_underscores/gcs_fail_on_underscores.wdl
+++ b/src/main/resources/standardTestCases/gcs_fail_on_underscores/gcs_fail_on_underscores.wdl
@@ -1,0 +1,21 @@
+task size_task {
+  Float sz
+
+  command {
+    echo "file has size ${sz}"
+  }
+  output {
+    File out = stdout()
+  }
+  runtime {
+    docker: "ubuntu:latest"
+  }
+}
+
+workflow size_wf {
+  File file
+  call size_task { input: sz = size(file) }
+
+  output {
+  }
+}

--- a/src/main/resources/standardTestCases/sub_function/sub_function.wdl
+++ b/src/main/resources/standardTestCases/sub_function/sub_function.wdl
@@ -12,8 +12,8 @@ task sub {
     String myBamString = "myfilename.bam"
     File myBamFile
     String swappedStr = sub(myBamString, ".bam$", ".txt")
-    # at this point myBamFile is not localized so path must be removed
-    String swappedFile = sub(sub(sub(myBamFile, "file:", ""), "/.*/",""), ".bam$", ".txt")
+    # At this point myBamFile is not localized so the protocol and path must be removed.
+    String swappedFile = sub(sub(sub(myBamFile, "^[a-z0-9]+:", ""), "/.*/",""), ".bam$", ".txt")
 
     command {
       echo ${sub(myBamString, ".bam$", ".txt")}


### PR DESCRIPTION
Also fix a triple-nested sub test to accommodate more than just the `file:` protocol.