### PR TITLE
One Cromwell is enough

### DIFF
--- a/test_cromwell.sh
+++ b/test_cromwell.sh
@@ -97,14 +97,6 @@ if [[ -n ${CROMWELL_BRANCH} ]]; then
     CROMWELL_JAR=$(find "${RUN_DIR}"/cromwell/target/scala-2.* -name "cromwell-*.jar")
 fi
 
-CROMWELL_MEM_ARGS="-Xmx3g"
-echo "Starting Cromwell, jar is ${CROMWELL_JAR}"
-if [ -n "$CONFIG_STRING" ]; then
-    java "${CROMWELL_MEM_ARGS}" "${CONFIG_STRING}" -jar "${CROMWELL_JAR}" server >> "${CROMWELL_LOG}" 2>&1 &
-else
-    java "${CROMWELL_MEM_ARGS}" -jar "${CROMWELL_JAR}" server >> "${CROMWELL_LOG}" 2>&1 &
-fi
-
 # Build and run centaur
 cd "${RUN_DIR}"
 


### PR DESCRIPTION
Looks like this found its way back in the script, however Centaur manages the Cromwell instance itself now so we don't need to launch it separately